### PR TITLE
Set scope=provided

### DIFF
--- a/opentracing-mongo-common/pom.xml
+++ b/opentracing-mongo-common/pom.xml
@@ -29,6 +29,7 @@
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
       <version>${mongo.driver.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/opentracing-mongo-driver-async/pom.xml
+++ b/opentracing-mongo-driver-async/pom.xml
@@ -31,11 +31,17 @@
       <artifactId>opentracing-mongo-common</artifactId>
       <version>0.1.5-SNAPSHOT</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongo-java-driver</artifactId>
+      <version>${mongo.driver.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongodb-driver-async</artifactId>
       <version>${mongo.driver.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/opentracing-mongo-driver/pom.xml
+++ b/opentracing-mongo-driver/pom.xml
@@ -31,6 +31,12 @@
       <artifactId>opentracing-mongo-common</artifactId>
       <version>0.1.5-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongo-java-driver</artifactId>
+      <version>${mongo.driver.version}</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Setting the scope of the target libraries of instrumentation to "provided". It is a guarantee that the integrating codebase will provide these libraries, otherwise the instrumentation plugin would be moot if the codebase does not already have these libraries.