### PR TITLE
Support buildInfo command in OperationCollectionSpanNameProvider

### DIFF
--- a/opentracing-mongo-common/src/main/java/io/opentracing/contrib/mongo/common/providers/OperationCollectionSpanNameProvider.java
+++ b/opentracing-mongo-common/src/main/java/io/opentracing/contrib/mongo/common/providers/OperationCollectionSpanNameProvider.java
@@ -15,6 +15,7 @@ package io.opentracing.contrib.mongo.common.providers;
 
 import com.mongodb.event.CommandStartedEvent;
 import org.bson.BsonDocument;
+import org.bson.BsonValue;
 
 public class OperationCollectionSpanNameProvider extends NoopSpanNameProvider {
 
@@ -24,7 +25,12 @@ public class OperationCollectionSpanNameProvider extends NoopSpanNameProvider {
       return NO_OPERATION;
     }
     final BsonDocument cmd = event.getCommand();
-    String col = cmd.getString(cmd.getFirstKey()).getValue();
-    return super.generateName(event) + " " + col;
+    BsonValue firstKey = cmd.get(cmd.getFirstKey());
+    if (firstKey.isString()) {
+      String collectionName = firstKey.asString().getValue();
+      return super.generateName(event) + " " + collectionName;
+    } else {
+      return super.generateName(event);
+    }
   }
 }

--- a/opentracing-mongo-common/src/test/java/io/opentracing/contrib/mongo/common/providers/OperationCollectionSpanNameProviderTest.java
+++ b/opentracing-mongo-common/src/test/java/io/opentracing/contrib/mongo/common/providers/OperationCollectionSpanNameProviderTest.java
@@ -13,33 +13,46 @@
  */
 package io.opentracing.contrib.mongo.common.providers;
 
-import static org.junit.Assert.assertEquals;
-
 import com.mongodb.ServerAddress;
 import com.mongodb.connection.ClusterId;
 import com.mongodb.connection.ConnectionDescription;
 import com.mongodb.connection.ServerId;
 import com.mongodb.event.CommandStartedEvent;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class OperationCollectionSpanNameProviderTest {
 
   private final MongoSpanNameProvider provider = new OperationCollectionSpanNameProvider();
 
-  private final CommandStartedEvent TEST_EVENT = new CommandStartedEvent(1,
-      new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
-      "database-name", "insert",
-      new BsonDocument().append("insert", new BsonString("collection-name")));
+  private final CommandStartedEvent INSERT_TEST_EVENT = new CommandStartedEvent(1,
+    new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
+    "database-name", "insert",
+    new BsonDocument().append("insert", new BsonString("collection-name")));
+
+  private final CommandStartedEvent BUILD_INFO_TEST_EVENT = new CommandStartedEvent(44,
+    new ConnectionDescription(new ServerId(new ClusterId(), new ServerAddress())),
+    "database-name", "buildInfo",
+    new BsonDocument()
+      .append("buildInfo", new BsonInt32(1))
+      .append("$db", new BsonString("database-name")));
 
   @Test
   public void testOperationNameExists() {
-    assertEquals("insert collection-name", provider.generateName(TEST_EVENT));
+    assertEquals("insert collection-name", provider.generateName(INSERT_TEST_EVENT));
   }
 
   @Test
   public void testNullOperationName() {
     assertEquals("unknown", provider.generateName(null));
+  }
+
+  @Test
+  public void testOperationNameNotString() {
+    assertEquals("buildInfo", provider.generateName(BUILD_INFO_TEST_EVENT));
   }
 }


### PR DESCRIPTION
Apparently [MongoReactiveHealthIndicator from `spring-boot-actuator`](https://github.com/spring-projects/spring-boot/blob/19ad163486f39ba7d8f05896c0a52ca7912f1bd9/spring-boot-project/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/mongo/MongoReactiveHealthIndicator.java#L46) is performing a health check that results in unwanted warning logs. 
The suggested solution in this PR is to check first if the command's first entry has string as value and if not, use `NoopSpanNameProvider#generateName` to print only command name.
Useless warning logs:
```java
2020-07-20 21:53:18.582  WARN 44312 --- [)-…] org.mongodb.driver.protocol.event        : Exception thrown raising command started event to listener io.opentracing.contrib.mongo.common.TracingCommandListener@6a455a4a

org.bson.BsonInvalidOperationException: Value expected to be of type STRING is of unexpected type INT32
	at org.bson.BsonValue.throwIfInvalidType(BsonValue.java:419) ~[mongo-java-driver-3.11.2.jar:na]
	at org.bson.BsonValue.asString(BsonValue.java:69) ~[mongo-java-driver-3.11.2.jar:na]
	at org.bson.BsonDocument.getString(BsonDocument.java:234) ~[mongo-java-driver-3.11.2.jar:na]
	at io.opentracing.contrib.mongo.common.providers.OperationCollectionSpanNameProvider.generateName(OperationCollectionSpanNameProvider.java:27) ~[opentracing-mongo-common-0.1.5.jar:na]
	at io.opentracing.contrib.mongo.common.TracingCommandListener.buildSpan(TracingCommandListener.java:172) ~[opentracing-mongo-common-0.1.5.jar:na]
	at io.opentracing.contrib.mongo.common.TracingCommandListener.commandStarted(TracingCommandListener.java:123) ~[opentracing-mongo-common-0.1.5.jar:na]
	at com.mongodb.internal.connection.ProtocolHelper.sendCommandStartedEvent(ProtocolHelper.java:277) ~[mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.LoggingCommandEventSender.sendStartedEvent(LoggingCommandEventSender.java:78) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.InternalStreamConnection.sendAndReceiveAsync(InternalStreamConnection.java:331) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.UsageTrackingInternalConnection.sendAndReceiveAsync(UsageTrackingInternalConnection.java:114) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultConnectionPool$PooledConnection.sendAndReceiveAsync(DefaultConnectionPool.java:461) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.CommandProtocolImpl.executeAsync(CommandProtocolImpl.java:78) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultServer$DefaultServerProtocolExecutor.executeAsync(DefaultServer.java:233) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultServerConnection.executeProtocolAsync(DefaultServerConnection.java:285) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultServerConnection.commandAsync(DefaultServerConnection.java:156) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultServerConnection.commandAsync(DefaultServerConnection.java:147) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.CommandOperationHelper.executeCommandAsyncWithConnection(CommandOperationHelper.java:451) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.CommandOperationHelper$8.call(CommandOperationHelper.java:415) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.OperationHelper$7.onResult(OperationHelper.java:614) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.OperationHelper$7.onResult(OperationHelper.java:611) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultServer$1.onResult(DefaultServer.java:116) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultServer$1.onResult(DefaultServer.java:105) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.async.ErrorHandlingResultCallback.onResult(ErrorHandlingResultCallback.java:49) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultConnectionPool.openAsync(DefaultConnectionPool.java:201) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultConnectionPool.getAsync(DefaultConnectionPool.java:158) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.DefaultServer.getConnectionAsync(DefaultServer.java:105) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.binding.AsyncClusterBinding$AsyncClusterBindingConnectionSource.getConnection(AsyncClusterBinding.java:139) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.OperationHelper.withAsyncConnectionSource(OperationHelper.java:611) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.OperationHelper.access$200(OperationHelper.java:63) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.OperationHelper$AsyncCallableWithConnectionAndSourceCallback.onResult(OperationHelper.java:631) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.OperationHelper$AsyncCallableWithConnectionAndSourceCallback.onResult(OperationHelper.java:619) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.async.ErrorHandlingResultCallback.onResult(ErrorHandlingResultCallback.java:49) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.binding.AsyncClusterBinding$1.onResult(AsyncClusterBinding.java:113) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.binding.AsyncClusterBinding$1.onResult(AsyncClusterBinding.java:107) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.BaseCluster$ServerSelectionRequest.onResult(BaseCluster.java:440) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.BaseCluster.handleServerSelectionRequest(BaseCluster.java:304) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.BaseCluster.selectServerAsync(BaseCluster.java:160) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.SingleServerCluster.selectServerAsync(SingleServerCluster.java:41) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.binding.AsyncClusterBinding.getAsyncClusterBindingConnectionSource(AsyncClusterBinding.java:107) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.binding.AsyncClusterBinding.getReadConnectionSource(AsyncClusterBinding.java:97) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.OperationHelper.withAsyncReadConnection(OperationHelper.java:558) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.CommandOperationHelper.executeCommandAsync(CommandOperationHelper.java:409) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.CommandOperationHelper.executeCommandAsync(CommandOperationHelper.java:389) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.operation.CommandReadOperation.executeAsync(CommandReadOperation.java:64) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.async.client.OperationExecutorImpl$1$1.onResult(OperationExecutorImpl.java:88) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.OperationExecutorImpl$1$1.onResult(OperationExecutorImpl.java:76) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.OperationExecutorImpl.getReadWriteBinding(OperationExecutorImpl.java:186) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.OperationExecutorImpl.access$200(OperationExecutorImpl.java:45) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.OperationExecutorImpl$1.onResult(OperationExecutorImpl.java:74) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.OperationExecutorImpl$1.onResult(OperationExecutorImpl.java:68) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.ClientSessionHelper$2.onResult(ClientSessionHelper.java:80) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.ClientSessionHelper$2.onResult(ClientSessionHelper.java:73) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.internal.connection.BaseCluster$ServerSelectionRequest.onResult(BaseCluster.java:440) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.BaseCluster.handleServerSelectionRequest(BaseCluster.java:304) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.BaseCluster.selectServerAsync(BaseCluster.java:160) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.internal.connection.SingleServerCluster.selectServerAsync(SingleServerCluster.java:41) [mongo-java-driver-3.11.2.jar:na]
	at com.mongodb.async.client.ClientSessionHelper.createClientSession(ClientSessionHelper.java:68) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.ClientSessionHelper.withClientSession(ClientSessionHelper.java:51) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.OperationExecutorImpl.execute(OperationExecutorImpl.java:68) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.MongoDatabaseImpl.executeCommand(MongoDatabaseImpl.java:232) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.MongoDatabaseImpl.runCommand(MongoDatabaseImpl.java:197) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.MongoDatabaseImpl.runCommand(MongoDatabaseImpl.java:191) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.reactivestreams.client.internal.MongoDatabaseImpl$1.apply(MongoDatabaseImpl.java:129) [mongodb-driver-reactivestreams-1.12.0.jar:na]
	at com.mongodb.reactivestreams.client.internal.MongoDatabaseImpl$1.apply(MongoDatabaseImpl.java:126) [mongodb-driver-reactivestreams-1.12.0.jar:na]
	at com.mongodb.async.client.SingleResultCallbackSubscription.requestInitialData(SingleResultCallbackSubscription.java:38) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.AbstractSubscription.tryRequestInitialData(AbstractSubscription.java:164) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.AbstractSubscription.request(AbstractSubscription.java:87) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.reactivestreams.client.internal.ObservableToPublisher$1$1.request(ObservableToPublisher.java:48) [mongodb-driver-reactivestreams-1.12.0.jar:na]
	at reactor.core.publisher.MonoFlatMapMany$FlatMapManyMain.onSubscribeInner(MonoFlatMapMany.java:143) [reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at reactor.core.publisher.MonoFlatMapMany$FlatMapManyInner.onSubscribe(MonoFlatMapMany.java:237) [reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at com.mongodb.reactivestreams.client.internal.SingleResultObservableToPublisher$1.onSubscribe(SingleResultObservableToPublisher.java:37) [mongodb-driver-reactivestreams-1.12.0.jar:na]
	at com.mongodb.reactivestreams.client.internal.ObservableToPublisher$1.onSubscribe(ObservableToPublisher.java:37) [mongodb-driver-reactivestreams-1.12.0.jar:na]
	at com.mongodb.async.client.SingleResultCallbackSubscription.<init>(SingleResultCallbackSubscription.java:33) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.async.client.Observables$2.subscribe(Observables.java:78) [mongodb-driver-async-3.11.2.jar:na]
	at com.mongodb.reactivestreams.client.internal.ObservableToPublisher.subscribe(ObservableToPublisher.java:34) [mongodb-driver-reactivestreams-1.12.0.jar:na]
	at com.mongodb.reactivestreams.client.internal.SingleResultObservableToPublisher.subscribe(SingleResultObservableToPublisher.java:34) [mongodb-driver-reactivestreams-1.12.0.jar:na]
	at reactor.core.publisher.MonoFlatMapMany$FlatMapManyMain.onNext(MonoFlatMapMany.java:188) [reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onNext$2(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onNext(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onNext$2(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onNext(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxDefaultIfEmpty$DefaultIfEmptySubscriber.onNext(FluxDefaultIfEmpty.java:92) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onNext$2(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onNext(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onNext(FluxOnErrorResume.java:73) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onNext$2(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onNext(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1637) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at reactor.core.publisher.MonoSupplier.subscribe(MonoSupplier.java:61) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4105) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at reactor.core.publisher.FluxOnErrorResume$ResumeSubscriber.onError(FluxOnErrorResume.java:97) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.onError(TracedSubscriber.java:79) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onError(MonoFlatMap.java:165) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.onError(TracedSubscriber.java:79) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onError(FluxFilterFuseable.java:156) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.onError(TracedSubscriber.java:79) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onError(FluxMapFuseable.java:134) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.onError(TracedSubscriber.java:79) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxHandleFuseable$HandleFuseableSubscriber.onNext(FluxHandleFuseable.java:185) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onNext$2(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onNext(TracedSubscriber.java:69) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.Operators$ScalarSubscription.request(Operators.java:2199) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$request$1(TracedSubscriber.java:64) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.request(TracedSubscriber.java:64) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxHandleFuseable$HandleFuseableSubscriber.request(FluxHandleFuseable.java:243) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$request$1(TracedSubscriber.java:64) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.request(TracedSubscriber.java:64) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.request(FluxMapFuseable.java:162) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$request$1(TracedSubscriber.java:64) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.request(TracedSubscriber.java:64) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.request(FluxFilterFuseable.java:184) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$request$1(TracedSubscriber.java:64) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.request(TracedSubscriber.java:64) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.MonoFlatMap$FlatMapMain.onSubscribe(MonoFlatMap.java:103) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onSubscribe$0(TracedSubscriber.java:59) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onSubscribe(TracedSubscriber.java:59) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onSubscribe(FluxFilterFuseable.java:81) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onSubscribe$0(TracedSubscriber.java:59) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onSubscribe(TracedSubscriber.java:59) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onSubscribe(FluxMapFuseable.java:90) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onSubscribe$0(TracedSubscriber.java:59) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onSubscribe(TracedSubscriber.java:59) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.FluxHandleFuseable$HandleFuseableSubscriber.onSubscribe(FluxHandleFuseable.java:148) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at io.opentracing.contrib.reactor.TracedSubscriber.lambda$onSubscribe$0(TracedSubscriber.java:59) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.withActiveSpan(TracedSubscriber.java:98) [opentracing-reactor-0.1.2.jar:na]
	at io.opentracing.contrib.reactor.TracedSubscriber.onSubscribe(TracedSubscriber.java:59) [opentracing-reactor-0.1.2.jar:na]
	at reactor.core.publisher.MonoCurrentContext.subscribe(MonoCurrentContext.java:35) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at reactor.core.publisher.InternalMonoOperator.subscribe(InternalMonoOperator.java:55) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at reactor.core.publisher.MonoDefer.subscribe(MonoDefer.java:52) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at reactor.core.publisher.Mono.subscribe(Mono.java:4105) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at reactor.core.publisher.Mono.block(Mono.java:1662) ~[reactor-core-3.3.2.RELEASE.jar:3.3.2.RELEASE]
	at org.springframework.boot.actuate.autoconfigure.health.HealthEndpointConfiguration$AdaptedReactiveHealthContributors$1.getHealth(HealthEndpointConfiguration.java:121) ~[spring-boot-actuator-autoconfigure-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpoint.getHealth(HealthEndpoint.java:81) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpoint.getHealth(HealthEndpoint.java:38) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getContribution(HealthEndpointSupport.java:108) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getAggregateHealth(HealthEndpointSupport.java:119) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getContribution(HealthEndpointSupport.java:105) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getHealth(HealthEndpointSupport.java:83) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpointSupport.getHealth(HealthEndpointSupport.java:70) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpoint.health(HealthEndpoint.java:75) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.health.HealthEndpoint.health(HealthEndpoint.java:65) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_212]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_212]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_212]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_212]
	at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:282) ~[spring-core-5.2.3.RELEASE.jar:5.2.3.RELEASE]
	at org.springframework.boot.actuate.endpoint.invoke.reflect.ReflectiveOperationInvoker.invoke(ReflectiveOperationInvoker.java:77) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.endpoint.annotation.AbstractDiscoveredOperation.invoke(AbstractDiscoveredOperation.java:60) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.endpoint.jmx.EndpointMBean.invoke(EndpointMBean.java:121) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at org.springframework.boot.actuate.endpoint.jmx.EndpointMBean.invoke(EndpointMBean.java:96) ~[spring-boot-actuator-2.2.4.RELEASE.jar:2.2.4.RELEASE]
	at com.sun.jmx.interceptor.DefaultMBeanServerInterceptor.invoke(DefaultMBeanServerInterceptor.java:819) ~[na:1.8.0_212]
	at com.sun.jmx.mbeanserver.JmxMBeanServer.invoke(JmxMBeanServer.java:801) ~[na:1.8.0_212]
	at javax.management.remote.rmi.RMIConnectionImpl.doOperation(RMIConnectionImpl.java:1468) ~[na:1.8.0_212]
	at javax.management.remote.rmi.RMIConnectionImpl.access$300(RMIConnectionImpl.java:76) ~[na:1.8.0_212]
	at javax.management.remote.rmi.RMIConnectionImpl$PrivilegedOperation.run(RMIConnectionImpl.java:1309) ~[na:1.8.0_212]
	at javax.management.remote.rmi.RMIConnectionImpl.doPrivilegedOperation(RMIConnectionImpl.java:1401) ~[na:1.8.0_212]
	at javax.management.remote.rmi.RMIConnectionImpl.invoke(RMIConnectionImpl.java:829) ~[na:1.8.0_212]
	at sun.reflect.GeneratedMethodAccessor65.invoke(Unknown Source) ~[na:na]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_212]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_212]
	at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:357) ~[na:1.8.0_212]
	at sun.rmi.transport.Transport$1.run(Transport.java:200) ~[na:1.8.0_212]
	at sun.rmi.transport.Transport$1.run(Transport.java:197) ~[na:1.8.0_212]
	at java.security.AccessController.doPrivileged(Native Method) ~[na:1.8.0_212]
	at sun.rmi.transport.Transport.serviceCall(Transport.java:196) ~[na:1.8.0_212]
	at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:573) ~[na:1.8.0_212]
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:834) ~[na:1.8.0_212]
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:688) ~[na:1.8.0_212]
	at java.security.AccessController.doPrivileged(Native Method) ~[na:1.8.0_212]
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:687) ~[na:1.8.0_212]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_212]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_212]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_212]
```